### PR TITLE
Modify anonymous class to static class due to bug #JDK-8034044

### DIFF
--- a/src/main/java/com/intel/distml/platform/MonitorActor.java
+++ b/src/main/java/com/intel/distml/platform/MonitorActor.java
@@ -284,13 +284,24 @@ public class MonitorActor extends UntypedActor implements PSManager.PSMonitor{
         log("Monitor created, psCount:" + psCount);
     }
 
+    private static final class CreatorImplementation implements Creator<MonitorActor> {  
+    	public CreatorImplementation(final Model model) {
+    		this.model = model;
+    	}
+        private static final long serialVersionUID = 1L;  
+        private Model model;
+  
+        public MonitorActor create() throws Exception {  
+            // TODO Auto-generated method stub  
+        	 return new MonitorActor(model);
+        }  
+    }  
+    
     public static Props props(final Model model) {
-        return Props.create(new Creator<MonitorActor>() {
-            private static final long serialVersionUID = 1L;
-            public MonitorActor create() throws Exception {
-                return new MonitorActor(model);
-            }
-        });
+    	
+    	 return Props.create(new CreatorImplementation(model));  
+    	
+    	
     }
 
     public void switchServer(int index, String addr, ActorRef actor) {


### PR DESCRIPTION
Oracle's implementation returns "static" for anonymous classes, which contradicts the spec. In order to make DistML run on more wild environments, I change the anonymous class to static class.
